### PR TITLE
Automatically create a Release on commit

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,34 +2,41 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Update Dependencies
-      run: sudo apt-get update
+      - name: Update Dependencies
+        run: sudo apt-get update
 
-    - name: Install LaTeX
-      run: sudo apt-get install -y texlive-xetex texlive-bibtex-extra biber
+      - name: Install LaTeX
+        run: sudo apt-get install -y texlive-xetex texlive-bibtex-extra biber
 
-    - name: Compile User Guide PDF
-      run: make
-    - uses: actions/upload-artifact@v3
-      with:
-        name: X16UsersGuide.pdf
-        path: x16_user_guide.pdf
+      - name: Compile User Guide PDF
+        run: make
+      - uses: actions/upload-artifact@v3
+        with:
+          name: X16UsersGuide.pdf
+          path: x16_user_guide.pdf
 
-    - name: Compile Getting Started Guide PDF
-      run: make getting_started
-    - uses: actions/upload-artifact@v3
-      with:
-        name: X16GettingStarted.pdf
-        path: x16_getting_started.pdf
+      - name: Compile Getting Started Guide PDF
+        run: make getting_started
+      - uses: actions/upload-artifact@v3
+        with:
+          name: X16GettingStarted.pdf
+          path: x16_getting_started.pdf
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: X16_Users_Guide
+          files: |
+            x16_user_guide.pdf
+            x16_getting_started.pdf


### PR DESCRIPTION
Updated the GitHub Action to automatically create a release whenever a new commit successfully compiles. Additionally, made some whitespace changes (apologies if this is not wanted). However, I see one glaring issue with this solution, and I think would require a change in how commits are handled in the repo to make this cleaner:

Every release will have the exact same name, but we can begin using git tags to track versioning of the documents we actually want to release, and use these for the release names. If this convention is adopted, then the workflow can be updated to only create a release on particular versions of the document. We could tag certain commits as "v1.0", "v1.1", or whatever the case may be, and only create a release on these version numbers.

If you'd like to proceed with using tags for creating milestones in the versioning history, I'd be more than happy to help update this automation to respect those tags.